### PR TITLE
Pass "ccls.xref" command name as a string, not a symbol, to lsp--send-execute-command...

### DIFF
--- a/ccls.el
+++ b/ccls.el
@@ -148,7 +148,7 @@ DIRECTION can be \"D\", \"L\", \"R\" or \"U\"."
 (cl-defmethod lsp-execute-command
   ((_server (eql ccls)) (command (eql ccls.xref)) arguments)
   (when-let ((xrefs (lsp--locations-to-xref-items
-                     (lsp--send-execute-command command arguments))))
+                     (lsp--send-execute-command "ccls.xref" arguments))))
     (xref--show-xrefs xrefs nil)))
 
 (advice-add 'lsp--suggest-project-root :before-until #'ccls--suggest-project-root)


### PR DESCRIPTION
...in the lsp-execute-command method definition.

This fixes error '(wrong-type-argument json-value-p ccls\.xref)' on attempt
to click on any code lens reference.

It seems that the old elisp-only json serializer did accept a symbol as a JSON
value and serialized it as a string; now, when Emacs is built with native JSON
support, it is not more valid.

P.S. Maybe `(symbol-name command)` would have been better, but since this method is explicitly restricted to ccls.xref, it seems passing the command name verbatim is OK?