### PR TITLE
Use proper icons for expanded/unexpanded nodes

### DIFF
--- a/ccls-tree.el
+++ b/ccls-tree.el
@@ -170,7 +170,7 @@
                          "◀ "
                        "")
                    (if (ccls-tree-node-has-children node)
-                       (if (ccls-tree-node-expanded node) "▶ " "▼ ")
+                       (if (ccls-tree-node-expanded node) "▼ " "▶ ")
                      (if (eq number (- nchildren 1)) "└╸" "├╸")))))
     (concat padding (propertize symbol 'face 'ccls-tree-icon-face))))
 


### PR DESCRIPTION
Now it looks like this: https://i.imgur.com/bDgHDSN.png and this I think is consistent with some GUI packages like Qt: https://i.stack.imgur.com/Ua7ef.jpg