### PR TITLE
Fix mouse-1 on 'N refs'

### DIFF
--- a/ccls-code-lens.el
+++ b/ccls-code-lens.el
@@ -69,8 +69,7 @@
       (lambda () (interactive)
         (when-let ((xrefs (lsp--locations-to-xref-items
                            (lsp--send-execute-command command arguments?))))
-          ;; xref--show-xrefs takes a function since Emacs 27.
-          (xref--show-xrefs (if (functionp 'xref--create-fetcher) (lambda () xrefs) xrefs) nil))))
+          (lsp-show-xrefs xrefs nil t))))
     (propertize (concat lpad title rpad)
                 'face 'ccls-code-lens-face
                 'mouse-face 'ccls-code-lens-mouse-face

--- a/ccls-code-lens.el
+++ b/ccls-code-lens.el
@@ -96,7 +96,7 @@
     (goto-char 1)
     (let ((line 0) (col 0) ov)
       (seq-doseq (lens result)
-        (-let (([l0 c0 l1 c1 command?] lens) (pad " "))
+        (-let (([l0 c0 l1 c1 command?] lens))
           (pcase ccls-code-lens-position
             ('end
              (forward-line (- l0 line))

--- a/ccls-semantic-highlight.el
+++ b/ccls-semantic-highlight.el
@@ -250,7 +250,7 @@ If nil, disable semantic highlight."
       (with-current-buffer buffer
         (with-silent-modifications
           (ccls--clear-sem-highlights)
-          (let (ranges point0 point1 (line 0) overlays)
+          (let (overlays)
             (seq-doseq (symbol symbols)
               (-when-let* ((face (funcall ccls-sem-face-function symbol)))
                 (seq-doseq (range (lsp:ccls-semantic-highlight-symbol-ranges symbol))

--- a/ccls-tree.el
+++ b/ccls-tree.el
@@ -273,7 +273,7 @@
       (unless lsp--buffer-workspaces
         (setq lsp--buffer-workspaces workspaces)
         (lsp-mode 1)
-        (dolist (workspace cur-buffer-workspaces)
+        (dolist (workspace workspaces)
           (lsp--open-in-workspace workspace)))
       (goto-char (lsp--position-to-point (cdr (ccls-tree-node-location node))))
       (recenter)

--- a/ccls.el
+++ b/ccls.el
@@ -149,7 +149,7 @@ DIRECTION can be \"D\", \"L\", \"R\" or \"U\"."
   ((_server (eql ccls)) (command (eql ccls.xref)) arguments)
   (when-let ((xrefs (lsp--locations-to-xref-items
                      (lsp--send-execute-command "ccls.xref" arguments))))
-    (xref--show-xrefs xrefs nil)))
+    (lsp-show-xrefs xrefs nil t)))
 
 (advice-add 'lsp--suggest-project-root :before-until #'ccls--suggest-project-root)
 

--- a/ccls.el
+++ b/ccls.el
@@ -70,7 +70,8 @@
 (defcustom ccls-initialization-options
   nil
   "initializationOptions"
-  :group 'ccls)
+  :group 'ccls
+  :type 'alist)
 (put 'ccls-initialization-options 'safe-local-variable 'listp)
 
 (defcustom ccls-root-files


### PR DESCRIPTION
Fix a few issues

- Using Emacs 27 on Linux, prior to this commit, when clicking on the 'N refs' annotation created by code lens, you would get "cl--assertion-failed: Assertion failed: (functionp fetcher)". See https://github.com/emacs-lsp/lsp-mode/issues/3838
-  void-variable cur-buffer-workspaces
- fix warnings

