### PR TITLE
fix: Drop support for Emacs 26.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
-          - 26.3
           - 27.2
           - 28.2
           - snapshot

--- a/Eask
+++ b/Eask
@@ -14,7 +14,7 @@
 (source "gnu")
 (source "melpa")
 
-(depends-on "emacs" "25.1")
+(depends-on "emacs" "27.1")
 (depends-on "lsp-mode")
 (depends-on "dash")
 

--- a/ccls.el
+++ b/ccls.el
@@ -7,7 +7,7 @@
 ;; Package-Version: 20200621
 ;; Version: 0.1
 ;; Homepage: https://github.com/MaskRay/emacs-ccls
-;; Package-Requires: ((emacs "25.1") (lsp-mode "6.3.1") (dash "2.14.1"))
+;; Package-Requires: ((emacs "27.1") (lsp-mode "6.3.1") (dash "2.14.1"))
 ;; Keywords: languages, lsp, c++
 
 ;; Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
See https://github.com/emacs-lsp/lsp-mode/pull/4126.