### PR TITLE
Re-evaluate `ccls-library-folders-fn`

### DIFF
--- a/ccls.el
+++ b/ccls.el
@@ -164,7 +164,8 @@ DIRECTION can be \"D\", \"L\", \"R\" or \"U\"."
   (lsp-ht ("$ccls/publishSkippedRanges" #'ccls--publish-skipped-ranges)
           ("$ccls/publishSemanticHighlight" #'ccls--publish-semantic-highlight))
   :initialization-options (lambda () ccls-initialization-options)
-  :library-folders-fn ccls-library-folders-fn))
+  :library-folders-fn (lambda (&rest args)
+                        (if ccls-library-folders-fn (apply ccls-library-folders-fn args)))))
 
 (provide 'ccls)
 ;;; ccls.el ends here


### PR DESCRIPTION
Customizing the variable `ccls-library-folders-fn` did not do anything, because the variable is evaluated once when the package loads. That occurs even before `custom.el` runs. This replaces the bare reference with a wrapper lambda that will pick up a new value of the variable.